### PR TITLE
fix missing header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ add_subdirectory(src)
 
 # install the include folder
 install(FILES ${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}/renderer.h
+              ${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}/renderer3d.h
                 ${${PROJECT_NAME}_include_files}
         DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}/
 )


### PR DESCRIPTION
renderer3d is included from both renderer_glut.h as well as renderer_osmesa.h 
but is not installed..
