### PR TITLE
-DUSE_GLUT=1 if glut is found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,13 @@ find_package(OpenCV REQUIRED)
 
 find_package(catkin REQUIRED)
 
-option(USE_GLUT "Use GLUT instead of OSMesa" OFF)
+find_package(GLUT QUIET)
 
-if (${USE_GLUT})
-find_package(GLUT)
-set(${PROJECT_NAME}_depends GLUT)
+if (${GLUT_FOUND})
+  message(STATUS "Using GLUT")
+  add_definitions(-DUSE_GLUT=1)
+  set(USE_GLUT TRUE)
+  set(${PROJECT_NAME}_depends GLUT)
 endif()
 
 catkin_package(INCLUDE_DIRS include


### PR DESCRIPTION
Hi @hris2003 and @vrabaud !

As discussed earlier this year on the Google User group [here](https://groups.google.com/forum/#!msg/object-recognition-kitchen/t-ZkdOjZdBI/jZ7KbkTlBgAJ),  there is some compilation issue when trying to compile without the proper mesa libraries. Since I am working with the KinectV2, I have to use glut instead.

The problem here is just that USE_GLUT never gets defined in renderer3d.cpp, only in cmake. That's why I use `add_definitions(-DUSE_GLUT=1)`.

I also propose `if (${GLUT_FOUND})` so that it's not required to change the option by hand.

It would be nice to also remove the dependency to libosmesa6-dev because it can actually build with glut instead. That way kinectV2 users could install all the debians of ORK.

Thanks for the great work by the way

Cheers,
Jimmy Da Silva
