### PR TITLE
Add textures to renderer

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -76,14 +76,14 @@ Model::recursiveTextureLoad(const struct aiScene *sc, const aiNode* nd)
 
       // See if another mesh is already using this texture, if so, just copy GLuint instead of remaking entire texture
       bool newTextureToBeLoaded = true;
-      for (int x = 0; x < texturesAndPaths.size(); x++)
+      for(std::map<std::pair<const aiNode*, int>, TextureAndPath>::iterator it = texturesAndPaths.begin(); it != texturesAndPaths.end(); ++it)
       {
-        if (texturesAndPaths[x].pathName == *str)
+        if(it->second.pathName == *str)
         {
           TextureAndPath reusedTexture;
-          reusedTexture.hTexture = texturesAndPaths[x].hTexture;
+          reusedTexture.hTexture = it->second.hTexture;
           reusedTexture.pathName = *str;
-          texturesAndPaths.push_back(reusedTexture);
+          texturesAndPaths[std::make_pair(nd, n)] = reusedTexture;
           newTextureToBeLoaded = false;
 
           std::cout << "Texture reused." << std::endl;
@@ -130,7 +130,7 @@ Model::recursiveTextureLoad(const struct aiScene *sc, const aiNode* nd)
 
         std::cout << "texture loaded." << std::endl;
 
-        texturesAndPaths.push_back(newTexture);
+        texturesAndPaths[std::make_pair(nd, n)] = newTexture;
       }
     }
   }
@@ -199,10 +199,11 @@ Model::recursive_render(const struct aiScene *sc, const aiNode* nd) const
   // draw all meshes assigned to this node
   for (; n < nd->mNumMeshes; ++n)
   {
+    glEnable(GL_TEXTURE_2D);
     const struct aiMesh* mesh = sc->mMeshes[nd->mMeshes[n]];
 
     if (n < texturesAndPaths.size())
-      glBindTexture(GL_TEXTURE_2D, texturesAndPaths[n].hTexture);
+      glBindTexture(GL_TEXTURE_2D, texturesAndPaths.at(std::make_pair(nd, n)).hTexture);
 
     apply_material(sc->mMaterials[mesh->mMaterialIndex]);
 

--- a/src/model.h
+++ b/src/model.h
@@ -39,6 +39,7 @@
 
 #include <FreeImage.h>
 #include <vector>
+#include <map>
 
 #include <iostream>
 
@@ -54,7 +55,7 @@ struct TextureAndPath
 class Model
 {
 private:
-  std::vector<TextureAndPath> texturesAndPaths;
+  std::map<std::pair<const aiNode*, int>, TextureAndPath> texturesAndPaths;
   const struct aiScene* scene;
 
   void


### PR DESCRIPTION
This PR is just the changes discussed on https://github.com/wg-perception/linemod/issues/10 and #8 

The following images show that the renderer now does show the textures on the renderer.
Though I guess that either the training or the detection doesn't really use texture properly because I can't see a difference between my three items (coke can, nestea can, mug)

![training](https://cloud.githubusercontent.com/assets/5452370/13152045/6b4b8638-d66d-11e5-919a-d3a00eaf8601.png)


![detection](https://cloud.githubusercontent.com/assets/5452370/13152043/63e7a124-d66d-11e5-9c45-d55350c624cd.png)

@nlyubova: that would be my starting point if you want to try linemod with a textured model
