### PR TITLE
Force glut to be down before doing glutInit

### DIFF
--- a/src/renderer3d_impl_glut.cpp
+++ b/src/renderer3d_impl_glut.cpp
@@ -38,12 +38,12 @@
 #include <GL/gl.h>
 #include <GL/glu.h>
 #include <GL/glut.h>
+#include <GL/freeglut_ext.h>
 
 #include "renderer3d_impl_glut.h"
 
 Renderer3dImpl::Renderer3dImpl(const std::string & file_path, int width, int height) :
-        Renderer3dImplBase(file_path, width, height),
-        is_glut_initialized_(false)
+        Renderer3dImplBase(file_path, width, height)
 {
 };
 
@@ -69,12 +69,11 @@ Renderer3dImpl::set_parameters_low_level()
   int argc = 0;
   char **argv = 0;
 
-  // Start GLUT if it was not started before
-  //if (glutGet(GLUT_ELAPSED_TIME) <= 0)
-  if (!is_glut_initialized_) {
-    is_glut_initialized_ = true;
-    glutInit(&argc, argv);
-  }
+  // Make sure glut is down
+  glutExit();
+  
+  // Initialize glut
+  glutInit(&argc, argv);
 
   // By doing so, the window is not open
   glutInitDisplayMode(GLUT_DOUBLE);

--- a/src/renderer3d_impl_glut.h
+++ b/src/renderer3d_impl_glut.h
@@ -69,8 +69,6 @@ public:
   virtual void
   bind_buffers() const;
 
-  /** States whether GLUT has been initialized or not */
-  bool is_glut_initialized_;
   /** The frame buffer object used for offline rendering */
   GLuint fbo_id_;
   /** The render buffer object used for offline depth rendering */


### PR DESCRIPTION
However Glut cannot be initialized more than once, it's sometimes difficult to keep track of whether glut is already running or not.
Easiest method is to kill glut everytime you want to initialize it.

Problem discussed here #11 and there https://github.com/wg-perception/linemod/issues/20