### PR TITLE
negate model x,y,z back to normal

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -47,6 +47,14 @@ void
 Model::LoadModel(const std::string & file_path)
 {
   scene = aiImportFile(file_path.c_str(), aiProcessPreset_TargetRealtime_Quality);
+  for (unsigned int i=0; i<scene->mNumMeshes; i++){
+    for (unsigned int j=0; j<scene->mMeshes[i]->mNumVertices; j++){
+      scene->mMeshes[i]->mVertices[j].x *= -1;
+      scene->mMeshes[i]->mVertices[j].y *= -1;
+      scene->mMeshes[i]->mVertices[j].z *= -1;
+    }
+  }
+
   recursiveTextureLoad(scene, scene->mRootNode);
 }
 


### PR DESCRIPTION
The visualizations generated are negated in all three dimensions currently. This is especially visible once the texture mapping (from @JimmyDaSilva ) is added to the renderer. This addition provides a simple fix by negating each dimension for each point. Thanks to @robustify and @kmhallen for finding the solution.